### PR TITLE
Issue #38: Support Merriam Webster's new class name

### DIFF
--- a/content_scripts.js
+++ b/content_scripts.js
@@ -253,10 +253,10 @@ function mainJob(url) {
 
   // http://www.merriam-webster.com/dictionary/cat
   else if (url.match(/http[s]?:\/\/*www.merriam-webster.com\/*/)) {
-    if (!$(".play-pron").length) {
+    if (!$("[class^='play-pron']").length) {
       return false;
     }
-    $(".play-pron").each(function() {
+    $("[class^='play-pron']").each(function() {
       const dir = $(this).attr("data-dir");
       const file = $(this).attr("data-file");
       const audioUrl =

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "author": "Chien Chun",
   "name": "__MSG_extName__",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
   "icons": {


### PR DESCRIPTION
For #38. 
The class name of the play pronunciation button becomes `play-pron-v2`.
Update the jQuery selector to select the class correctly.
![image](https://user-images.githubusercontent.com/7236196/208234653-1d7b8e4c-e52e-4132-83b6-51d17d22f40e.png)
