### PR TITLE
Added MOE Taiwanese and fixed Forvo

### DIFF
--- a/content_scripts.js
+++ b/content_scripts.js
@@ -29,6 +29,7 @@ function mainJob(url) {
         }
         $(".dict-sound > audio").each(function() {
           const audioUrl = $(this).attr("src");
+          // const audioUrl = 'http://www.google.com/';
           insertDownloadLink(audioUrl, $(this).parent());
         });
         return true;
@@ -46,6 +47,18 @@ function mainJob(url) {
     }
 
     captureUrlWithRetry(0);
+  }
+
+  // https://sutian.moe.edu.tw/zh-hant/su/6912/
+  else if (url.match(/http[s]?:\/\/*sutian.moe.edu.tw\/*/)) {
+    if (!$(".imtong-liua").length) {
+      return false;
+    }
+    $(".imtong-liua").each(function() {
+      // const audioUrl = $(this).attr("data-src-mp3");
+      const audioUrl = 'http://www.google.com';
+      insertDownloadLink(audioUrl, $(this).parent());
+    });
   }
 
   // http://www.oxfordlearnersdictionaries.com/definition/english/wall_1?q=wall

--- a/content_scripts.js
+++ b/content_scripts.js
@@ -50,16 +50,14 @@ function mainJob(url) {
   }
 
   // https://sutian.moe.edu.tw/zh-hant/su/6912/
-  else if (url.match(/http[s]?:\/\/*sutian.moe.edu.tw\/*/)) {
-    if (!$(".imtong-liua").length) {
-      return false;
+    else if (url.includes("sutian.moe.edu.tw")){
+        if(!$(".imtong-liua").length){
+            return false;
+        }
+        $(".imtong-liua").each(function () {
+            insertDownloadLink($(this).attr("data-src"), $(this));
+        })
     }
-    $(".imtong-liua").each(function() {
-      // const audioUrl = $(this).attr("data-src-mp3");
-      const audioUrl = 'http://www.google.com';
-      insertDownloadLink(audioUrl, $(this).parent());
-    });
-  }
 
   // http://www.oxfordlearnersdictionaries.com/definition/english/wall_1?q=wall
   else if (url.match(/http[s]?:\/\/*www.oxfordlearnersdictionaries.com\/*/)) {
@@ -73,10 +71,14 @@ function mainJob(url) {
   }
   // https://forvo.com/
   else if (url.match(/http[s]?:\/\/*forvo.com\/*/)) {
-    if (!$("span.play").length) {
+	  console.log('in forvo');
+    // if (!$("span.play").length) {
+    if (!$("div.play").length) {
       return false;
     }
-    $("span.play").each(function() {
+    // $("span.play").each(function() {
+    $("div.play").each(function() {
+		console.log('span play');
       const playStr = $(this).attr("onclick");
       // Parse the Play() function body
       const playParams = playStr

--- a/content_scripts.js
+++ b/content_scripts.js
@@ -29,7 +29,6 @@ function mainJob(url) {
         }
         $(".dict-sound > audio").each(function() {
           const audioUrl = $(this).attr("src");
-          // const audioUrl = 'http://www.google.com/';
           insertDownloadLink(audioUrl, $(this).parent());
         });
         return true;
@@ -71,14 +70,10 @@ function mainJob(url) {
   }
   // https://forvo.com/
   else if (url.match(/http[s]?:\/\/*forvo.com\/*/)) {
-	  console.log('in forvo');
-    // if (!$("span.play").length) {
     if (!$("div.play").length) {
       return false;
     }
-    // $("span.play").each(function() {
     $("div.play").each(function() {
-		console.log('span play');
       const playStr = $(this).attr("onclick");
       // Parse the Play() function body
       const playParams = playStr

--- a/manifest.json
+++ b/manifest.json
@@ -89,7 +89,9 @@
     "http://dict.leo.org/*",
     "https://dict.leo.org/*",
     "http://forvo.com/*",
-    "https://forvo.com/*"
+    "https://forvo.com/*",
+	"http://sutian.moe.edu.tw/",
+	"https://sutian.moe.edu.tw/"
   ],
   "content_scripts": [
     {
@@ -174,7 +176,9 @@
         "http://dict.leo.org/*",
         "https://dict.leo.org/*",
         "http://forvo.com/*",
-        "https://forvo.com/*"
+        "https://forvo.com/*",
+		"http://sutian.moe.edu.tw/",
+		"https://sutian.moe.edu.tw/"
       ]
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -90,8 +90,8 @@
     "https://dict.leo.org/*",
     "http://forvo.com/*",
     "https://forvo.com/*",
-	"http://sutian.moe.edu.tw/",
-	"https://sutian.moe.edu.tw/"
+	"http://sutian.moe.edu.tw/*",
+	"https://sutian.moe.edu.tw/*"
   ],
   "content_scripts": [
     {
@@ -177,8 +177,8 @@
         "https://dict.leo.org/*",
         "http://forvo.com/*",
         "https://forvo.com/*",
-		"http://sutian.moe.edu.tw/",
-		"https://sutian.moe.edu.tw/"
+		"http://sutian.moe.edu.tw/*",
+		"https://sutian.moe.edu.tw/*"
       ]
     }
   ],


### PR DESCRIPTION
MOE Taiwanese is available now (https://sutian.moe.edu.tw/)
台灣教育部台語常用辭典

 Forvo is fixed.